### PR TITLE
Update StartDate in Entity model following change of start date

### DIFF
--- a/src/AcceptanceTests/Features/Features/RecalculatePaymentsFromEarnings.feature
+++ b/src/AcceptanceTests/Features/Features/RecalculatePaymentsFromEarnings.feature
@@ -12,7 +12,7 @@ Scenario: Payments Recalculation
 	When payments are recalculated
 	Then new payments are generated with the correct learning amounts
 
-Scenario: Payments Recalculation when start date is changed to ealier date
+Scenario: Payments Recalculation when start date is changed to earlier date
 	Given there are 20 payments of 600, which started 8 months ago
 	And recalculated earnings now have 22 payments of 545.45, which started 10 months ago
 	When payments are recalculated

--- a/src/AcceptanceTests/Helpers/PeriodHelper.cs
+++ b/src/AcceptanceTests/Helpers/PeriodHelper.cs
@@ -4,24 +4,6 @@ namespace SFA.DAS.Funding.ApprenticeshipPayments.AcceptanceTests.Helpers;
 
 public static class PeriodHelper
 {
-    public static void SetDeliveryPeriodsAccordingToCalendarMonths(this EarningsGeneratedEvent earningsGeneratedEvent)
-    {
-        foreach (var deliveryPeriod in earningsGeneratedEvent.DeliveryPeriods)
-        {
-            deliveryPeriod.AcademicYear = deliveryPeriod.CalenderYear.ToAcademicYear(deliveryPeriod.CalendarMonth);
-            deliveryPeriod.Period = deliveryPeriod.CalendarMonth.ToDeliveryPeriod();
-        }
-    }
-
-    public static void SetDeliveryPeriodsAccordingToCalendarMonths(this ApprenticeshipEarningsRecalculatedEvent earningsRecalculatedEvent)
-    {
-        foreach (var deliveryPeriod in earningsRecalculatedEvent.DeliveryPeriods)
-        {
-            deliveryPeriod.AcademicYear = deliveryPeriod.CalenderYear.ToAcademicYear(deliveryPeriod.CalendarMonth);
-            deliveryPeriod.Period = deliveryPeriod.CalendarMonth.ToDeliveryPeriod();
-        }
-    }
-
     public static byte ToDeliveryPeriod(this byte calendarMonth)
     {
         if (calendarMonth < 8)
@@ -37,5 +19,16 @@ public static class PeriodHelper
             return short.Parse($"{calendarYearTwoDigit - 1}{calendarYearTwoDigit}");
 
         return short.Parse($"{calendarYearTwoDigit}{calendarYearTwoDigit + 1}");
+    }
+
+    public static DeliveryPeriod CreateDeliveryPeriod(byte calendarMonth, short calendarYear, decimal learningAmount)
+    {
+        return new DeliveryPeriod(
+            calendarMonth,
+            calendarYear, 
+            calendarMonth.ToDeliveryPeriod(), 
+            calendarYear.ToAcademicYear(calendarMonth), 
+            learningAmount, 
+            "fundingLineType");
     }
 }

--- a/src/AcceptanceTests/SFA.DAS.Funding.ApprenticeshipPayments.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/SFA.DAS.Funding.ApprenticeshipPayments.AcceptanceTests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="AutoFixture" Version="4.18.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.33" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="4.0.1" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.9.5" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.10.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.4" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />

--- a/src/AcceptanceTests/StepDefinitions/EarningsGeneratedEventPublishingStepDefinitions.cs
+++ b/src/AcceptanceTests/StepDefinitions/EarningsGeneratedEventPublishingStepDefinitions.cs
@@ -32,9 +32,9 @@ public class EarningsGeneratedEventPublishingStepDefinitions
     {
         var periods = new List<DeliveryPeriod>
         {
-            new() { CalenderYear = (short)DateTime.Now.Year, CalendarMonth = (byte)DateTime.Now.Month, LearningAmount = 1000 },
-            new() { CalenderYear = (short)DateTime.Now.AddMonths(1).Year, CalendarMonth = (byte)DateTime.Now.AddMonths(1).Month, LearningAmount = 1000 },
-            new() { CalenderYear = (short)DateTime.Now.AddMonths(2).Year, CalendarMonth = (byte)DateTime.Now.AddMonths(2).Month, LearningAmount = 1000 }
+            PeriodHelper.CreateDeliveryPeriod((byte)DateTime.Now.Month, (short)DateTime.Now.Year, 1000),
+            PeriodHelper.CreateDeliveryPeriod((byte)DateTime.Now.AddMonths(1).Month, (short)DateTime.Now.AddMonths(1).Year, 1000),
+            PeriodHelper.CreateDeliveryPeriod((byte)DateTime.Now.AddMonths(2).Month, (short)DateTime.Now.AddMonths(2).Year, 1000)
         };
 
         _earningsGeneratedEvent = _testContext.Fixture
@@ -43,8 +43,6 @@ public class EarningsGeneratedEventPublishingStepDefinitions
             .With(x => x.Uln, _testContext.Fixture.Create<int>().ToString())
             .With(x => x.TrainingCode, _testContext.Fixture.Create<int>().ToString())
             .Create();
-
-        _earningsGeneratedEvent.SetDeliveryPeriodsAccordingToCalendarMonths();
     }
 
     [Given(@"two of the earnings are due in a past month")]
@@ -52,9 +50,9 @@ public class EarningsGeneratedEventPublishingStepDefinitions
     {
         var periods = new List<DeliveryPeriod>
         {
-            new() { CalenderYear = (short)DateTime.Now.AddMonths(-2).Year, CalendarMonth = (byte)DateTime.Now.AddMonths(-2).Month, LearningAmount = 1000 },
-            new() { CalenderYear = (short)DateTime.Now.AddMonths(-1).Year, CalendarMonth = (byte)DateTime.Now.AddMonths(-1).Month, LearningAmount = 1000 },
-            new() { CalenderYear = (short)DateTime.Now.Year, CalendarMonth = (byte)DateTime.Now.Month, LearningAmount = 1000 }
+             PeriodHelper.CreateDeliveryPeriod((byte)DateTime.Now.Month, (short)DateTime.Now.Year, 1000),
+             PeriodHelper.CreateDeliveryPeriod((byte)DateTime.Now.AddMonths(-2).Month, (short)DateTime.Now.AddMonths(-2).Year, 1000),
+             PeriodHelper.CreateDeliveryPeriod((byte)DateTime.Now.AddMonths(-1).Month, (short)DateTime.Now.AddMonths(-1).Year, 1000)
         };
 
         _earningsGeneratedEvent = _testContext.Fixture
@@ -63,8 +61,6 @@ public class EarningsGeneratedEventPublishingStepDefinitions
             .With(x => x.Uln, _testContext.Fixture.Create<int>().ToString())
             .With(x => x.TrainingCode, _testContext.Fixture.Create<int>().ToString())
             .Create();
-
-        _earningsGeneratedEvent.SetDeliveryPeriodsAccordingToCalendarMonths();
     }
 
     [Given(@"no payments have previously been generated")]

--- a/src/AcceptanceTests/StepDefinitions/PaymentsRecalculationStepDefinitions.cs
+++ b/src/AcceptanceTests/StepDefinitions/PaymentsRecalculationStepDefinitions.cs
@@ -84,8 +84,8 @@ public class PaymentsRecalculationStepDefinitions
 	{
 		var periods = new List<DeliveryPeriod>
 		{
-			new() { CalenderYear = (short)DateTime.Now.Year, CalendarMonth = (byte)DateTime.Now.Month, LearningAmount = 1000 }, //this month already paid
-			new() { CalenderYear = (short)DateTime.Now.AddMonths(1).Year, CalendarMonth = (byte)DateTime.Now.AddMonths(1).Month, LearningAmount = 1000 } // next month not paid yet
+            PeriodHelper.CreateDeliveryPeriod((byte)DateTime.Now.Month, (short)DateTime.Now.Year, 1000),
+            PeriodHelper.CreateDeliveryPeriod((byte)DateTime.Now.AddMonths(1).Month, (short)DateTime.Now.AddMonths(1).Year, 1000)  // next month not paid yet
 		};
 
 		await GenerateExistingPayments(periods);
@@ -100,7 +100,7 @@ public class PaymentsRecalculationStepDefinitions
 
 		for (var i = 0; i < totalNumberOfPayments; i++)
         {
-            periods.Add(new() { CalenderYear = (short)startDate.AddMonths(i).Year, CalendarMonth = (byte)startDate.AddMonths(i).Month, LearningAmount = paymentAmount });
+            periods.Add(PeriodHelper.CreateDeliveryPeriod((byte)DateTime.Now.AddMonths(i).Month, (short)DateTime.Now.AddMonths(i).Year, 1000));
 		}
 
         await GenerateExistingPayments(periods);
@@ -112,8 +112,8 @@ public class PaymentsRecalculationStepDefinitions
         //build event for recalculated earnings
         var periods = new List<DeliveryPeriod>
         {
-            new() { CalenderYear = (short)DateTime.Now.Year, CalendarMonth = (byte)DateTime.Now.Month, LearningAmount = 1200 }, //this month already paid
-            new() { CalenderYear = (short)DateTime.Now.AddMonths(1).Year, CalendarMonth = (byte)DateTime.Now.AddMonths(1).Month, LearningAmount = 1200 } // next month not paid yet
+            PeriodHelper.CreateDeliveryPeriod((byte)DateTime.Now.Month, (short)DateTime.Now.Year, 1200), //this month already paid
+            PeriodHelper.CreateDeliveryPeriod((byte)DateTime.Now.AddMonths(1).Month, (short)DateTime.Now.AddMonths(1).Year, 1200) // next month not paid yet
         };
 
 		await GenerateRecalculatedEarnings(periods);
@@ -128,7 +128,7 @@ public class PaymentsRecalculationStepDefinitions
 
 		for (var i = 0; i < totalNumberOfPayments; i++)
 		{
-			periods.Add(new() { CalenderYear = (short)startDate.AddMonths(i).Year, CalendarMonth = (byte)startDate.AddMonths(i).Month, LearningAmount = paymentAmount });
+			periods.Add(PeriodHelper.CreateDeliveryPeriod((byte)DateTime.Now.AddMonths(i).Month, (short)DateTime.Now.AddMonths(i).Year, paymentAmount));
 		}
 
 		await GenerateRecalculatedEarnings(periods);
@@ -172,8 +172,6 @@ public class PaymentsRecalculationStepDefinitions
 			.With(x => x.ApprenticeshipKey, _apprenticeshipKey)
 			.Create();
 
-		_previousEarningsGeneratedEvent.SetDeliveryPeriodsAccordingToCalendarMonths();
-
 		_scenarioContext[ContextKeys.EarningsGeneratedEvent] = _previousEarningsGeneratedEvent;
 
 		//publish event for previous earnings
@@ -211,8 +209,6 @@ public class PaymentsRecalculationStepDefinitions
 			.With(x => x.DeliveryPeriods, periods)
 			.With(x => x.ApprenticeshipKey, _apprenticeshipKey)
 			.Create();
-
-		_earningsRecalculatedEvent.SetDeliveryPeriodsAccordingToCalendarMonths();
 
 		_scenarioContext[ContextKeys.EarningsRecalculatedEvent] = _earningsRecalculatedEvent;
 

--- a/src/AcceptanceTests/StepDefinitions/PaymentsRecalculationStepDefinitions.cs
+++ b/src/AcceptanceTests/StepDefinitions/PaymentsRecalculationStepDefinitions.cs
@@ -84,7 +84,7 @@ public class PaymentsRecalculationStepDefinitions
 	{
 		var periods = new List<DeliveryPeriod>
 		{
-            PeriodHelper.CreateDeliveryPeriod((byte)DateTime.Now.Month, (short)DateTime.Now.Year, 1000),
+            PeriodHelper.CreateDeliveryPeriod((byte)DateTime.Now.Month, (short)DateTime.Now.Year, 1000), //this month already paid
             PeriodHelper.CreateDeliveryPeriod((byte)DateTime.Now.AddMonths(1).Month, (short)DateTime.Now.AddMonths(1).Year, 1000)  // next month not paid yet
 		};
 
@@ -100,7 +100,7 @@ public class PaymentsRecalculationStepDefinitions
 
 		for (var i = 0; i < totalNumberOfPayments; i++)
         {
-            periods.Add(PeriodHelper.CreateDeliveryPeriod((byte)DateTime.Now.AddMonths(i).Month, (short)DateTime.Now.AddMonths(i).Year, 1000));
+            periods.Add(PeriodHelper.CreateDeliveryPeriod((byte)DateTime.Now.AddMonths(i).Month, (short)DateTime.Now.AddMonths(i).Year, paymentAmount));
 		}
 
         await GenerateExistingPayments(periods);

--- a/src/AcceptanceTests/StepDefinitions/PaymentsRecalculationStepDefinitions.cs
+++ b/src/AcceptanceTests/StepDefinitions/PaymentsRecalculationStepDefinitions.cs
@@ -100,7 +100,7 @@ public class PaymentsRecalculationStepDefinitions
 
 		for (var i = 0; i < totalNumberOfPayments; i++)
         {
-            periods.Add(PeriodHelper.CreateDeliveryPeriod((byte)DateTime.Now.AddMonths(i).Month, (short)DateTime.Now.AddMonths(i).Year, paymentAmount));
+            periods.Add(PeriodHelper.CreateDeliveryPeriod((byte)startDate.AddMonths(i).Month, (short)startDate.AddMonths(i).Year, paymentAmount));
 		}
 
         await GenerateExistingPayments(periods);
@@ -128,7 +128,7 @@ public class PaymentsRecalculationStepDefinitions
 
 		for (var i = 0; i < totalNumberOfPayments; i++)
 		{
-			periods.Add(PeriodHelper.CreateDeliveryPeriod((byte)DateTime.Now.AddMonths(i).Month, (short)DateTime.Now.AddMonths(i).Year, paymentAmount));
+			periods.Add(PeriodHelper.CreateDeliveryPeriod((byte)startDate.AddMonths(i).Month, (short)startDate.AddMonths(i).Year, paymentAmount));
 		}
 
 		await GenerateRecalculatedEarnings(periods);

--- a/src/DurableEntities.UnitTests/ApprenticeshipEntity_HandleEarningsRecalculatedEventTests.cs
+++ b/src/DurableEntities.UnitTests/ApprenticeshipEntity_HandleEarningsRecalculatedEventTests.cs
@@ -74,6 +74,12 @@ public class ApprenticeshipEntity_HandleEarningsRecalculatedEventTests
     }
 
     [Test]
+    public void ShouldMapStartDate()
+    {
+        _sut.Model.StartDate.Should().Be(_earningsRecalculatedEvent.StartDate);
+    }
+    
+    [Test]
     public void ShouldMapEarnings()
     {
         _sut.Model.Earnings.Should().BeEquivalentTo(_expectedEarnings);

--- a/src/DurableEntities/ApprenticeshipEntity.cs
+++ b/src/DurableEntities/ApprenticeshipEntity.cs
@@ -48,6 +48,7 @@ namespace SFA.DAS.Funding.ApprenticeshipPayments.DurableEntities
 
             var apprenticeship = await _recalculateApprenticeshipPaymentsCommandHandler.Recalculate(new RecalculateApprenticeshipPaymentsCommand(Model, earningsRecalculatedEvent.DeliveryPeriods.ToEarnings(earningsRecalculatedEvent.EarningsProfileId)));
 
+            MapNewApprenticeshipValues(earningsRecalculatedEvent);
             MapNewEarningsAndPayments(apprenticeship);
         }
 
@@ -108,6 +109,11 @@ namespace SFA.DAS.Funding.ApprenticeshipPayments.DurableEntities
                 SentForPayment = p.SentForPayment,
                 EarningsProfileId = p.EarningsProfileId
             }).ToList();
+        }
+
+        private void MapNewApprenticeshipValues(ApprenticeshipEarningsRecalculatedEvent earningsRecalculatedEvent)
+        {
+            Model.StartDate = earningsRecalculatedEvent.StartDate;
         }
     }
 }

--- a/src/DurableEntities/EarningsFunctions.cs
+++ b/src/DurableEntities/EarningsFunctions.cs
@@ -33,7 +33,8 @@ namespace SFA.DAS.Funding.ApprenticeshipPayments.DurableEntities
             [DurableClient] IDurableEntityClient client,
             ILogger log)
         {
-            await client.SignalEntityAsync(new EntityId(nameof(ApprenticeshipEntity), earningsRecalculatedEvent.ApprenticeshipKey.ToString()), nameof(ApprenticeshipEntity.HandleEarningsRecalculatedEvent), earningsRecalculatedEvent);
+            var entityId = new EntityId(nameof(ApprenticeshipEntity), earningsRecalculatedEvent.ApprenticeshipKey.ToString());
+            await client.SignalEntityAsync(entityId, nameof(ApprenticeshipEntity.HandleEarningsRecalculatedEvent), earningsRecalculatedEvent);
         }
     }
 }

--- a/src/DurableEntities/SFA.DAS.Funding.ApprenticeshipPayments.DurableEntities.csproj
+++ b/src/DurableEntities/SFA.DAS.Funding.ApprenticeshipPayments.DurableEntities.csproj
@@ -6,13 +6,14 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.9.5" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.10.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.5.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.22.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NServiceBus.Extensions.DependencyInjection" Version="1.0.1" />
     <PackageReference Include="SFA.DAS.Configuration.AzureTableStorage" Version="3.0.84" />
+    <PackageReference Include="SFA.DAS.Funding.ApprenticeshipEarnings.Types" Version="1.0.27-prerelease-10" />
     <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.1.2" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/src/TestHelpers/SFA.DAS.Funding.ApprenticeshipPayments.TestHelpers.csproj
+++ b/src/TestHelpers/SFA.DAS.Funding.ApprenticeshipPayments.TestHelpers.csproj
@@ -27,7 +27,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.33" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.9.5" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.10.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.4" />
     <PackageReference Include="Microsoft.SqlServer.DacFx" Version="160.6161.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/src/Types/SFA.DAS.Funding.ApprenticeshipPayments.Types.csproj
+++ b/src/Types/SFA.DAS.Funding.ApprenticeshipPayments.Types.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.7.4" />
     <PackageReference Include="SFA.DAS.Apprenticeships.Types" Version="1.1.4" />
-    <PackageReference Include="SFA.DAS.Funding.ApprenticeshipEarnings.Types" Version="1.0.21-prerelease-3" />
+    <PackageReference Include="SFA.DAS.Funding.ApprenticeshipEarnings.Types" Version="1.0.27-prerelease-10" />
     <PackageReference Include="SFA.DAS.Payments.Monitoring.Jobs.Messages" Version="0.0.14" />
     <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="7.0.2" />


### PR DESCRIPTION
It's been acknowledged that this pattern of adding apprenticeship values that need updating to the incoming integration event will make it become bloated and that we need a better way of handling different values that may need changing following a change of circumstance (currently this will always update the start date regardless of whether it has actually changed).
Therefore, this is a temporary simple solution to resolve the bug until the introduction of "ApprenticeshipEpisodes".